### PR TITLE
Disable rails 6 build for old ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,8 @@ branches:
   only:
     - master
     - rails6
-matrix:
-  fast_finish: true
 jobs:
+  fast_finish: true
   exclude:
   - rvm: 2.4.2
     gemfile: test/gemfiles/Gemfile.rails.6.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,7 @@ branches:
     - rails6
 matrix:
   fast_finish: true
+jobs:
+  exclude:
+  - rvm: 2.4.2
+    gemfile: test/gemfiles/Gemfile.rails.6.0


### PR DESCRIPTION
Tweak build matrix to skip building rails 6 with old ruby.